### PR TITLE
feat: add light mode toggle

### DIFF
--- a/src/main/resources/static/css/generalStyles.css
+++ b/src/main/resources/static/css/generalStyles.css
@@ -1,3 +1,60 @@
 .goto-login, .goto-register, .goto-login a, .goto-register a {
     color: #f0d0d0 !important;
 }
+
+/* Light mode overrides */
+body.light-mode {
+    background: linear-gradient(135deg, #ffffff 0%, #eaeaea 100%);
+    color: #000000;
+}
+
+body.light-mode .navbar-custom,
+body.light-mode .card,
+body.light-mode .card-header,
+body.light-mode .card-footer,
+body.light-mode .list-group-item {
+    background-color: #ffffff;
+    border-color: #dddddd;
+    color: #000000;
+}
+
+body.light-mode .navbar-brand,
+body.light-mode .icon-link,
+body.light-mode .card-title,
+body.light-mode .card-text,
+body.light-mode .table th,
+body.light-mode .table td {
+    color: #000000 !important;
+}
+
+body.light-mode .text-muted {
+    color: #6c757d !important;
+}
+
+body.light-mode .btn-outline-primary,
+body.light-mode .btn-outline-secondary,
+body.light-mode .btn-outline-success,
+body.light-mode .btn-outline-danger,
+body.light-mode .btn-outline-light {
+    border-color: #000000;
+    color: #000000;
+}
+
+body.light-mode .btn-outline-primary:hover,
+body.light-mode .btn-outline-secondary:hover,
+body.light-mode .btn-outline-success:hover,
+body.light-mode .btn-outline-danger:hover,
+body.light-mode .btn-outline-light:hover {
+    background-color: #000000;
+    color: #ffffff;
+}
+
+.btn-outline-light {
+    border-color: #d0d0d0;
+    color: #d0d0d0;
+}
+
+.btn-outline-light:hover {
+    background-color: #d0d0d0;
+    color: #000000;
+}

--- a/src/main/resources/static/css/userProfile.css
+++ b/src/main/resources/static/css/userProfile.css
@@ -181,3 +181,4 @@ body {
         padding: 1rem;
     }
 }
+

--- a/src/main/resources/static/js/userProfile.js
+++ b/src/main/resources/static/js/userProfile.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const editUserInfoBtn = document.getElementById('edit-user-info-btn');
+  const configUserBtn = document.getElementById('config-user-btn');
+  const formEditUserInfo = document.getElementById('form-edit-user-info');
+  const userInfo = document.getElementById('userFullName');
+  const closeCreateClassFormBtn = document.getElementById('close-create-class-form-btn');
+  const themeToggleBtn = document.getElementById('toggle-theme');
+  const body = document.body;
+
+  if (editUserInfoBtn && configUserBtn && formEditUserInfo && userInfo && closeCreateClassFormBtn) {
+    editUserInfoBtn.addEventListener('click', () => {
+      userInfo.classList.add('hidden');
+      formEditUserInfo.classList.remove('hidden');
+      editUserInfoBtn.classList.add('hidden');
+      configUserBtn.classList.add('hidden');
+    });
+
+    closeCreateClassFormBtn.addEventListener('click', () => {
+      userInfo.classList.remove('hidden');
+      formEditUserInfo.classList.add('hidden');
+      editUserInfoBtn.classList.remove('hidden');
+      configUserBtn.classList.remove('hidden');
+    });
+  }
+
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme === 'light') {
+    body.classList.add('light-mode');
+    if (themeToggleBtn) themeToggleBtn.textContent = 'Dark Mode';
+  }
+
+  if (themeToggleBtn) {
+    themeToggleBtn.addEventListener('click', () => {
+      const isLight = body.classList.toggle('light-mode');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      themeToggleBtn.textContent = isLight ? 'Dark Mode' : 'Light Mode';
+    });
+  }
+});
+

--- a/src/main/resources/templates/userProfile.html
+++ b/src/main/resources/templates/userProfile.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- CSS -->
+  <link rel="stylesheet" th:href="@{/css/generalStyles.css}">
   <link rel="stylesheet" th:href="@{/css/userProfile.css}">
   <link rel="stylesheet" th:href="@{/css/header.css}">
 </head>
@@ -23,6 +24,7 @@
         <a class="icon-link" th:href="@{/my-account}">
           My Account
         </a>
+        <button id="toggle-theme" class="btn btn-outline-light ms-2">Light Mode</button>
       </div>
     </div>
   </nav>
@@ -56,7 +58,7 @@
   </div>
 
   <div class="row mb-4">
-    <div class="col-md-3 mb-3">
+    <div class="col-md-4 mb-3">
       <div class="card stats-card bg-primary text-white">
         <div class="card-body">
           <h5 class="card-title">Total Tasks</h5>
@@ -65,7 +67,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3 mb-3">
+    <div class="col-md-4 mb-3">
       <div class="card stats-card bg-success text-white">
         <div class="card-body">
           <h5 class="card-title">Completed</h5>
@@ -74,16 +76,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3 mb-3">
-      <div class="card stats-card bg-warning text-dark">
-        <div class="card-body">
-          <h5 class="card-title">In progress</h5>
-          <h2 class="card-text" id="inProgressTasks">0</h2>
-          <p class="card-text"><small th:text="'% in progress'"></small></p>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-3 mb-3">
+    <div class="col-md-4 mb-3">
       <div class="card stats-card bg-danger text-white">
         <div class="card-body">
           <h5 class="card-title">Pending</h5>
@@ -154,12 +147,11 @@
                   <h6 class="mb-1" th:text="${task.getTitle()}"></h6>
                   <small class="text-muted" th:text="${task.getCreatedAt()}"></small>
                 </div>
-                <span th:if="${task.getFinishedAt()} == null" class="badge bg-warning text-dark">In Progress</span>
                 <span class="badge bg-success" th:if="${task.getFinishedAt() != null}">Completed</span>
-              </div>
-            </li>
-          </ul>
-        </div>
+                </div>
+              </li>
+            </ul>
+          </div>
         <div class="card-footer text-end">
           <a href="/home" class="btn btn-sm btn-outline-primary">View all tasks</a>
         </div>
@@ -167,26 +159,6 @@
     </div>
   </div>
 </div>
-<script>
-  let $editUserInfoBtn = document.getElementById('edit-user-info-btn');
-  let $configUserBtn = document.getElementById('config-user-btn');
-  let $formEditUserInfo = document.getElementById('form-edit-user-info');
-  let $userInfo = document.getElementById('userFullName');
-  let $closeCreateClassFormBtn = document.getElementById('close-create-class-form-btn');
-
-  $editUserInfoBtn.addEventListener("click", () => {
-    $userInfo.classList.add('hidden');
-    $formEditUserInfo.classList.remove('hidden');
-    $editUserInfoBtn.classList.add('hidden');
-    $configUserBtn.classList.add('hidden');
-  });
-
-  $closeCreateClassFormBtn.addEventListener("click", () => {
-    $userInfo.classList.remove('hidden');
-    $formEditUserInfo.classList.add('hidden');
-    $editUserInfoBtn.classList.remove('hidden');
-    $configUserBtn.classList.remove('hidden');
-  });
-</script>
+<script th:src="@{/js/userProfile.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add light mode toggle button with state persisted in localStorage
- separate profile page scripts into userProfile.js and enable theme switching
- remove obsolete "In progress" status section from profile stats
- centralize light mode CSS in generalStyles.css for use across pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_6897da3e3134832c8c935b20badd8162